### PR TITLE
Features/extend configuration

### DIFF
--- a/actions/info/index.js
+++ b/actions/info/index.js
@@ -198,16 +198,31 @@ function info(verbose) {
         });
 }
 
+function dump_configuration() {
+    return tarifaFile.parse(pathHelper.root()).then(function (localSettings) {
+        print("%s\n%s",
+            chalk.green('tarifa configuration after the parsing:'),
+            JSON.stringify(localSettings, null, 2)
+        );
+    });
+}
+
 module.exports = function (argv) {
     var verbose = false,
         helpPath = path.join(__dirname, 'usage.txt');
 
-    if(argsHelper.matchArgumentsCount(argv, [0])
-            && argsHelper.checkValidOptions(argv, ['V', 'verbose'])) {
+    var validArguments = argsHelper.matchArgumentsCount(argv, [0]) &&
+                            argsHelper.checkValidOptions(argv, ['V', 'verbose', 'dump-configuration']);
+
+    if(validArguments) {
         if(argsHelper.matchOption(argv, 'V', 'verbose')) {
             verbose = true;
         }
-        return info(verbose);
+        if (argsHelper.matchOption(argv, null, 'dump-configuration')) {
+            return dump_configuration();
+        } else {
+            return info(verbose);
+        }
     }
     return fs.read(helpPath).then(print);
 };

--- a/actions/info/usage.txt
+++ b/actions/info/usage.txt
@@ -6,7 +6,7 @@ Options:
 
     --help, -h            Show this message
     --verbose, -V         Be more verbose on everything
-    --dump-configuration  Dump the tarifa configuration after the parsing
+    --dump-configuration  Display the tarifa configuration after the parsing is done
 
 Examples:
 

--- a/actions/info/usage.txt
+++ b/actions/info/usage.txt
@@ -4,8 +4,9 @@ Get some information about your environment and your devices.
 
 Options:
 
-    --help, -h     Show this message
-    --verbose, -V  Be more verbose on everything
+    --help, -h            Show this message
+    --verbose, -V         Be more verbose on everything
+    --dump-configuration  Dump the tarifa configuration after the parsing
 
 Examples:
 

--- a/lib/tarifa-file/extend_syntax.js
+++ b/lib/tarifa-file/extend_syntax.js
@@ -1,0 +1,82 @@
+var Q = require('q'),
+    collections = require('../helper/collections'),
+    format = require('util').format;
+
+/**
+ * Implement "extend" attribute inside configurations objects.
+ * It allows to extend objects defined in "configurations_mixins".
+ *
+ * {
+ *   "configurations_mixins": {
+ *     "green": {
+ *       assets_path: "images/green"
+ *     }
+ *   },
+ *   "configurations": {
+ *     "ios": {
+ *       "green_dev": {
+ *         "extend": "green"
+ *       }
+ *     }
+ *   }
+ * }
+ *
+ * Will result in an extended configuration
+ * { ..
+ *   "configurations": {
+ *     "ios": {
+ *       "green_dev": {
+ *         "extend": "green",
+ *         "assets_path": "images/green"
+ *       }
+ *     }
+ *   }
+ * }
+ */
+
+function extendSyntax(settings) {
+    var errors = [];
+
+    var mixins = settings.configurations_mixins || {};
+    mapConfigurations(settings, function(configuration, platformName, configurationName) {
+        if (configuration.hasOwnProperty('extend')) {
+            if (!mixins.hasOwnProperty(configuration.extend)) {
+                errors.push(format('Invalid configuration mixin "%s" extended in platform "%s", configuration "%s"', configuration.extend, platformName, configurationName));
+                return configuration;
+            } else {
+                return collections.mergeObject(mixins[configuration.extend], configuration, true);
+            }
+        } else {
+          return configuration;
+        }
+    });
+
+    if (errors.length > 0) {
+        return Q.reject(errors.join("\n"));
+    } else {
+        return settings;
+    }
+
+    return settings;
+}
+
+/**
+ * Map all configurations for all platforms with a callback function.
+ *
+ * `settings` tarifa configuration
+ * `callback` Called with three arguments: configuration, platform name
+ *            and configuration name. Expects a configuration in return.
+ */
+
+function mapConfigurations(settings, callback) {
+    var platforms = settings.platforms || [];
+    platforms.forEach(function(platform) {
+        if (settings.configurations && settings.configurations[platform]) {
+            Object.keys(settings.configurations[platform]).forEach(function(configurationName) {
+                settings.configurations[platform][configurationName] = callback(settings.configurations[platform][configurationName], platform, configurationName);
+            });
+        }
+    });
+}
+
+module.exports = extendSyntax;

--- a/lib/tarifa-file/parse.js
+++ b/lib/tarifa-file/parse.js
@@ -7,6 +7,7 @@ var path = require('path'),
     validator = require('../helper/validator'),
     collections = require('../helper/collections'),
     settings = require('../settings'),
+    extendSyntax = require('./extend_syntax'),
     checkProjectName = require('./validate/checkProjectName');
 
 function checkSigningLabel(platform, config, attributes, filePaths) {
@@ -180,6 +181,7 @@ module.exports = function (dirname, platform, config) {
         Object.defineProperty(mergedObj, 'tarifa:userPrivateKeys', descriptor);
         return mergedObj;
     })
+    .then(extendSyntax)
     // validate settings globally
     .then(checkGlobalSettings(platform, config))
     // check if name match native app name

--- a/test/common-tests.js
+++ b/test/common-tests.js
@@ -1,0 +1,7 @@
+require('./xml/config.xml');
+require('./xml/android/string.xml');
+require('./xml/android/project');
+require('./xml/android/AndroidManifest.xml');
+require('./xml/wp8/csproj');
+require('./xml/wp8/WMAppManifest.xml');
+require('./tarifa-file/extend_tests');

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,2 @@
-require('./xml/config.xml');
-require('./xml/android/string.xml');
-require('./xml/android/project');
-require('./xml/android/AndroidManifest.xml');
-require('./xml/wp8/csproj');
-require('./xml/wp8/WMAppManifest.xml');
-require('./tarifa-file/extend_tests');
+require('./common-tests');
 require('./test')({ run: false });

--- a/test/index.js
+++ b/test/index.js
@@ -4,4 +4,5 @@ require('./xml/android/project');
 require('./xml/android/AndroidManifest.xml');
 require('./xml/wp8/csproj');
 require('./xml/wp8/WMAppManifest.xml');
+require('./tarifa-file/extend_tests');
 require('./test')({ run: false });

--- a/test/tarifa-file/extend_tests.js
+++ b/test/tarifa-file/extend_tests.js
@@ -1,0 +1,119 @@
+var assert = require('assert'),
+    Q = require('q'),
+    extendSyntax = require('../../lib/tarifa-file/extend_syntax');
+
+var extendFixtureNominal = {
+  "platforms": ["ios", "android"],
+  "configurations_mixins": {
+    "green": {
+      "assets_path": "images/green",
+      "cordova": {
+        "preferences": {
+          "StatusBarBackgroundColor": "#34AD8F"
+        }
+      }
+    },
+    "blue": {
+      "assets_path": "images/blue"
+    },
+  },
+  "configurations": {
+    "ios": {
+      "green_dev": {
+        "extend": "green",
+        "should_be_kept": "yes"
+      },
+      "blue_dev": {
+        "extend": "blue"
+      },
+      "red_dev": {
+        "name": "Red name"
+      }
+    },
+    "android": {
+      "green_dev": {
+        "extend": "green"
+      },
+      "blue_dev": {
+        "extend": "blue"
+      }
+    }
+  }
+};
+
+var extendFixtureFailure = {
+  "platforms": ["android"],
+
+  "configurations": {
+    "android": {
+      "default": {
+        "extend": "nonexistent"
+      }
+    }
+  }
+};
+
+describe("extend a configuration", function() {
+    it("should extend mixin from configurations_mixins", function () {
+        var extended = extendSyntax(extendFixtureNominal);
+
+        var green_extended_ios = extended.configurations.ios.green_dev;
+        var red_extended_ios = extended.configurations.ios.red_dev;
+        var blue_extended_android = extended.configurations.android.blue_dev;
+
+        var green_mixin = extendFixtureNominal.configurations_mixins.green;
+        var blue_mixin = extendFixtureNominal.configurations_mixins.blue;
+
+        assert.equal(
+            green_extended_ios.assets_path,
+            green_mixin.assets_path,
+            "Shallow extend for green configuration in ios"
+        );
+
+        assert.equal(
+            blue_extended_android.assets_path,
+            blue_mixin.assets_path,
+            "Shallow extend for blue configuration in android"
+        );
+
+        assert.deepEqual(
+            green_extended_ios.cordova,
+            { "preferences": { "StatusBarBackgroundColor": "#34AD8F" } },
+            "Deep extend"
+        );
+
+        assert.equal(
+            green_extended_ios.should_be_kept,
+            "yes",
+            "Should keep values that are not in mixin"
+        );
+
+        assert.equal(
+            red_extended_ios.name,
+            "Red name",
+            "Should keep configurations even if they don't extend anything"
+        );
+    });
+
+    it("should throw an error when a mixin doesn't exist", function() {
+        var extended = extendSyntax(extendFixtureFailure);
+        var inspected = Q(extended).inspect();
+
+        assert.equal(inspected.state, "rejected", "Must be rejected");
+
+        assert.notStrictEqual(inspected.reason.match(/mixin "nonexistent"/), null, "Rejection message should contain mixin name");
+        assert.notStrictEqual(inspected.reason.match(/platform "android"/), null, "Rejection message should contain platform name");
+        assert.notStrictEqual(inspected.reason.match(/configuration "default"/), null, "Rejection message should contain configuration name");
+    });
+
+    it("should not throw any error when called with an empty object", function() {
+        assert.deepEqual(extendSyntax({}), {});
+
+        var confOnlyWithPlatforms = {"platforms": ["ios","android"]};
+        assert.deepEqual(extendSyntax(confOnlyWithPlatforms), confOnlyWithPlatforms);
+
+        var withEmptyConfs = {"platforms": ["ios","android"], "configurations": {"a":{"b":"c"}} };
+        assert.deepEqual(extendSyntax(withEmptyConfs), withEmptyConfs);
+    });
+
+});

--- a/test/with-devices.js
+++ b/test/with-devices.js
@@ -4,4 +4,5 @@ require('./xml/android/project');
 require('./xml/android/AndroidManifest.xml');
 require('./xml/wp8/csproj');
 require('./xml/wp8/WMAppManifest.xml');
+require('./tarifa-file/extend_tests');
 require('./test')({ run: true });

--- a/test/with-devices.js
+++ b/test/with-devices.js
@@ -1,8 +1,2 @@
-require('./xml/config.xml');
-require('./xml/android/string.xml');
-require('./xml/android/project');
-require('./xml/android/AndroidManifest.xml');
-require('./xml/wp8/csproj');
-require('./xml/wp8/WMAppManifest.xml');
-require('./tarifa-file/extend_tests');
+require('./common-tests');
 require('./test')({ run: true });


### PR DESCRIPTION
Implement extend attribut in configurations to extend `configurations_mixins`. Add tests. 
Add a new option `--dump-configuration` to tarifa info to display the tarifa configuration after the parsing.