### PR TITLE
Don't delete images by default when add/removing a platform

### DIFF
--- a/actions/platform/usage.txt
+++ b/actions/platform/usage.txt
@@ -15,6 +15,8 @@ Available commands:
 
 Options:
 
+    --prune        Delete assets on removal
+
     --help, -h     Show this message
     --verbose, -V  Be more verbose on everything
 


### PR DESCRIPTION
Add a '--prune' option to delete assets on removal
Fixes #173 

The prune option could also delete configurations (which is not the case atm). What do you think @peutetre ?