### PR TITLE
Implement tarifa plugin add --variable

### DIFF
--- a/actions/plugin/index.js
+++ b/actions/plugin/index.js
@@ -79,10 +79,11 @@ function raw_plugin (root, action, arg, variables, verbose) {
         });
 }
 
-function getVariableFromCli(v) {
-    var kv = v.split('=');
-    var res = {};
-    res[kv[0]] = kv[1];
+function getVariableFromCli(v, rst) {
+    var kv = v.split('='),
+        res = rst || {};
+    if (kv.length > 1) res[kv[0]] = kv[1];
+    else throw new Error('Wrong variable format');
     return res;
 }
 
@@ -99,9 +100,7 @@ function action (argv) {
             variables = argv.variable;
             if(variables instanceof Array)
                 variables = variables.reduce(function(acc, val) {
-                    var kv = val.split('=');
-                    acc[kv[0]] = kv[1];
-                    return acc;
+                  return getVariableFromCli(val, acc);
                 }, {});
             else
                 variables = getVariableFromCli(variables);

--- a/actions/plugin/usage.txt
+++ b/actions/plugin/usage.txt
@@ -13,6 +13,8 @@ Available commands:
 
 Options:
 
+    --variable     Only for `add` command, defines variable
+                   to be passed to the cordova plugin on install
     --help, -h     Show this message
     --verbose, -V  Be more verbose on everything
 
@@ -21,3 +23,4 @@ Examples:
     tarifa plugin add https://github.com/peutetre/cordova-plugin-hockeyapp.git#0.0.0
     tarifa plugin add org.apache.cordova.vibration
     tarifa plugin add ./relative/path/to/a/cordova/plugin
+    tarifa plugin add ./relative/path/to/a/cordova/plugin-with-variables --variable MY_VAR1=oops --variable MY_VAR42=42

--- a/lib/cordova/plugins.js
+++ b/lib/cordova/plugins.js
@@ -14,7 +14,7 @@ var path = require('path'),
 
 function list(root) {
     return Q.resolve(findPlugins(path.join(root, settings.cordovaAppPath, 'plugins')));
-};
+}
 
 function listAll() {
     var tarifaPlugins = JSON.parse(fs.readFileSync(path.join(__dirname, '../plugins.json'))),
@@ -23,15 +23,15 @@ function listAll() {
 
     if(userPlugins) return tarifaPlugins.concat(userPlugins);
     else return tarifaPlugins;
-};
+}
 
-function change(cmd, root, val) {
+function change(cmd, root, val, opts) {
     return list(root).then(function (beforeList) {
         var cordova_path = path.join(root, settings.cordovaAppPath),
             cwd = process.cwd(),
             resolved = fs.existsSync(pathHelper.resolve(val)) ? pathHelper.resolve(val) : val;
         process.chdir(cordova_path);
-        return cordova.raw.plugin(cmd, resolved).then(function () {
+        return cordova.raw.plugin(cmd, resolved, opts).then(function () {
             process.chdir(cwd);
             return list(root).then(function(afterList) {
                 var diff = difference(beforeList, afterList);
@@ -74,14 +74,15 @@ function change(cmd, root, val) {
         }).then(function (id) {
             return {
                 val : id,
-                uri : val
+                uri : val,
+                variables: opts && opts.cli_variables
             };
         });
     });
 }
 
-module.exports.add = function add(root, uri) {
-    return change('add', root, uri);
+module.exports.add = function add(root, uri, opts) {
+    return change('add', root, uri, opts);
 };
 
 module.exports.remove = function remove(root, name) {

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,6 +1,7 @@
 var Q = require('q'),
     tarifaFile = require('./tarifa-file'),
     questions = require('./questions/list'),
+    collections = require('./helper/collections'),
     print = require('./helper/print');
 
 function createFromResponse(response) {
@@ -10,10 +11,20 @@ function createFromResponse(response) {
 function mapToResponse(verbose) {
     return function (localSettings) {
         var plugins = Object.keys(localSettings.plugins).map(function (plugin) {
-                return {
+                var pluginObj = localSettings.plugins[plugin];
+                var uri, variables, res;
+                if(collections.isObject(pluginObj)) {
+                    uri = pluginObj.uri;
+                    variables = pluginObj.variables;
+                } else {
+                    uri = pluginObj;
+                }
+                res = {
                     value: plugin,
-                    uri: localSettings.plugins[plugin]
+                    uri: uri
                 };
+                if (variables) res.variables = variables;
+                return res;
             }),
             response = {
                 createProjectFromTarifaFile: true,

--- a/lib/helper/collections.js
+++ b/lib/helper/collections.js
@@ -106,3 +106,7 @@ module.exports.toMultiLevelObject = function (obj) {
   });
   return into;
 };
+
+module.exports.isObject = function(x) {
+  return x && typeof x === "object";
+};

--- a/lib/helper/print.js
+++ b/lib/helper/print.js
@@ -19,6 +19,11 @@ function todo(/* format, [ args ... ]*/) {
     console.log(chalk.bgYellow.blue('TODO'), ' ', util.format.apply(this, args));
 }
 
+function info(/* format, [ args ... ]*/) {
+    var args = Array.prototype.slice.call(arguments, 0);
+    console.log(chalk.green(figures.info), ' ', util.format.apply(this, args));
+}
+
 function success(/* format, [ args ... ]*/) {
     var args = Array.prototype.slice.call(arguments, 0);
     console.log(chalk.green(figures.star), ' ', util.format.apply(this, args));
@@ -53,6 +58,7 @@ chalk.red('           \\/__/   ') + chalk.green('  \\|__|     \\/__/   ') + chal
 
 module.exports = print;
 module.exports.trace = trace;
+module.exports.info = info;
 module.exports.success = success;
 module.exports.error = error;
 module.exports.warning = warning;

--- a/lib/questions/tasks/plugins.js
+++ b/lib/questions/tasks/plugins.js
@@ -9,8 +9,8 @@ var Q = require('q'),
     pathHelper = require('../../helper/path'),
     tarifaFile = require('../../tarifa-file');
 
-function add_cordova_plugin (root, name, uri, fromTarifaFile) {
-    return plugins.add(root, uri).then(function () {
+function add_cordova_plugin (root, name, uri, variables, fromTarifaFile) {
+    return plugins.add(root, uri, { cli_variables: variables }).then(function () {
         return fromTarifaFile ? Q() : tarifaFile.addPlugin(root, name, uri);
     });
 }
@@ -42,7 +42,7 @@ module.exports = function (response) {
 
     return mapPlugins(response).plugins.reduce(function (promise, plugin) {
         return promise.then(function () {
-            return add_cordova_plugin(root, plugin.value, plugin.uri, fromTarifaFile).then(function () {
+            return add_cordova_plugin(root, plugin.value, plugin.uri, plugin.variables, fromTarifaFile).then(function () {
                 if (response.options.verbose)
                     print.success('cordova plugin %s added', plugin.value);
                 return Q.resolve(response);

--- a/lib/tarifa-file/index.js
+++ b/lib/tarifa-file/index.js
@@ -129,10 +129,14 @@ function rawPlatformConfigObject(platform, obj) {
     return o;
 }
 
-tarifaFile.addPlugin = function (dirname, name, uri) {
+tarifaFile.addPlugin = function (dirname, name, uri, variables) {
     return tarifaFile.parse(dirname, null, null, true, true).then(function (obj) {
+        var value;
         if(!obj.plugins) obj.plugins = {};
-        obj.plugins[name] = uri;
+        if(variables !== undefined)
+            obj.plugins[name] = { uri: uri, variables: variables };
+        else
+            obj.plugins[name] = uri;
         return write(dirname, obj).then(function () { return name; });
     });
 };

--- a/lib/tarifa-file/index.js
+++ b/lib/tarifa-file/index.js
@@ -131,12 +131,8 @@ function rawPlatformConfigObject(platform, obj) {
 
 tarifaFile.addPlugin = function (dirname, name, uri, variables) {
     return tarifaFile.parse(dirname, null, null, true, true).then(function (obj) {
-        var value;
         if(!obj.plugins) obj.plugins = {};
-        if(variables !== undefined)
-            obj.plugins[name] = { uri: uri, variables: variables };
-        else
-            obj.plugins[name] = uri;
+        obj.plugins[name] = variables ? { uri: uri, variables: variables } : uri;
         return write(dirname, obj).then(function () { return name; });
     });
 };


### PR DESCRIPTION
I tested under various conditions.

It works from cli: `tarifa plugin add https://github.com/EddyVerbruggen/LaunchMyApp-PhoneGap-Plugin.git --variable URL_SCHEME=mycoolapp`
Also with two variables: `tarifa plugin add https://github.com/phonegap/phonegap-facebook-plugin.git --variable APP_ID='appId' --variable APP_NAME=appName`

After install, tarifa.json will looks like:
```
    "com.phonegap.plugins.facebookconnect": {
      "uri": "https://github.com/phonegap/phonegap-facebook-plugin.git",
      "variables": {
        "APP_ID": "appId",
        "APP_NAME": "appName"
      }
    }
```

Install from config works too with `tarifa check --force`.

Note: there is a bug in cordova when you installed a plugin with variables and you reinstall the platform (`tarifa platform remove android && tarifa platform add android` won't work).

But this bug can now be overcome with `tarifa check --force`