### PR TITLE
add support for team name with spaces

### DIFF
--- a/lib/platforms/ios/lib/nomad/provisioning/download.js
+++ b/lib/platforms/ios/lib/nomad/provisioning/download.js
@@ -10,7 +10,7 @@ var Q = require('q'),
 
 function download(user, team, password, name, profile_path) {
     var defer = Q.defer(),
-        t = (team ? (' --team ' + team) : ''),
+        t = (team ? (' --team \'' + team + '\'') : ''),
         cmd = format(
             '%s profiles:download %s -u %s -p $\'%s\' %s --type distribution',
             settings.external.ios.name,

--- a/lib/platforms/ios/lib/nomad/provisioning/list.js
+++ b/lib/platforms/ios/lib/nomad/provisioning/list.js
@@ -20,7 +20,7 @@ function list(user, team, password) {
             timeout: 40000,
             maxBuffer: 1024 * 400
         },
-        t = (team ? (' --team ' + team) : ''),
+        t = (team ? (' --team \'' + team + '\'') : ''),
         cmd = format(
             '%s profiles:list -u %s -p $\'%s\' %s --type distribution',
             settings.external.ios.name,


### PR DESCRIPTION
Yes it's bad but tarifa silently fail in this case.