### PR TITLE
add support for version number

### DIFF
--- a/actions/version/index.js
+++ b/actions/version/index.js
@@ -1,0 +1,58 @@
+var Q = require('q'),
+    rimraf = require('rimraf'),
+    spinner = require('char-spinner'),
+    path = require('path'),
+    fs = require('q-io/fs'),
+    argsHelper = require('../../lib/helper/args'),
+    pathHelper = require('../../lib/helper/path'),
+    log = require('../../lib/helper/log'),
+    tarifaFile = require('../../lib/tarifa-file');
+
+var set = function (version) {
+    var cwd = process.cwd(),
+        conf = [tarifaFile.parse(pathHelper.root())];
+
+    return Q.all(conf).spread(function (config) {
+        config.version = version;
+        return Q.when(config, function (c) {
+            return tarifaFile.write(cwd, c);
+        });
+    }).then(function (msg) {
+        process.chdir(cwd);
+        return msg;
+    }, function (err) {
+        process.chdir(cwd);
+        throw err;
+    });
+};
+
+var get = function () {
+    var conf = [tarifaFile.parse(pathHelper.root())];
+
+    return Q.all(conf).spread(function (config) {
+        return Q.resolve(config.version);
+    }).then(function (msg) {
+        if(msg) log.send('msg', msg);
+        return msg;
+    }, function (err) {
+        throw err;
+    });
+};
+
+var actions = {
+  get: get,
+  set: set
+};
+
+var action = function (argv) {
+    var helpOpt = argsHelper.matchSingleOption(argv, 'h', 'help');
+    if(argsHelper.matchArgumentsCount(argv, [0, 1, 2]) && !helpOpt) {
+      var method = actions[argv._[0] || 'get'];
+      if (method) {
+        return method(argv._[1]);
+      }
+    }
+    return fs.read(path.join(__dirname, 'usage.txt')).then(console.log);
+};
+
+module.exports = action;

--- a/actions/version/usage.txt
+++ b/actions/version/usage.txt
@@ -1,0 +1,14 @@
+Usage: tarifa version [action]
+
+Will either return the version number or set the current version number of the application
+
+Options:
+
+    --help, -h     Show this message
+    --verbose, -V  Be more verbose on everything
+    --debug, -d    Print helpful stack trace on error
+
+Examples:
+
+    tarifa version                # will return the version of the application
+    tarifa version set 1.2.3      # will set the version of the application to 1.2.3

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -41,6 +41,7 @@ var availableActions = [
         { name: 'update', action: '../actions/update' },
         { name: 'watch', action: '../actions/watch' },
         { name: 'test', action: '../actions/test'},
+        { name: 'version', action: '../actions/version'},
         { name: 'device', action: '../actions/device'},
         { name: 'devices', action: '../actions/device'} // alias
     ],


### PR DESCRIPTION
This small action is really helpful to update the version number while in an automated process without the need to open Xcode.