### PR TITLE
fix path for npm3

### DIFF
--- a/lib/platforms/ios/actions/run/tasks/install.js
+++ b/lib/platforms/ios/actions/run/tasks/install.js
@@ -13,7 +13,7 @@ var install = function (conf, device) {
         app_path = path.join(pathHelper.app(), 'platforms/ios', product_name + '.app'),
         iosDeploy = path.join('node_modules', 'ios-deploy', 'build', 'Release', 'ios-deploy'),
         npm2Path = path.join(__dirname, '../../../../../../', iosDeploy),
-        npm3Path = path.join(__dirname, '../../../../../../../', iosDeploy),
+        npm3Path = path.join(__dirname, '../../../../../../../../', iosDeploy),
         bin = pathHelper.isFile(npm2Path) ? npm2Path : npm3Path;
         args = ['-i', device, '-b', app_path, '--verbose', '--no-wifi'];
 


### PR DESCRIPTION
 ENOENT `<my-project>/node_modules/node_modules/ios-deploy/build/Release/ios-deploy`

The path was duplicating `node_modules` since it was going one level too early

When I add this, it works flawlessly on my side.