### PR TITLE
Allow specifying content in tarifa.json.

### DIFF
--- a/lib/platforms/shared/actions/build/tasks/populate_config_xml.js
+++ b/lib/platforms/shared/actions/build/tasks/populate_config_xml.js
@@ -16,6 +16,7 @@ module.exports = function (msg) {
         version = conf.version || local.version,
         preferences = local.cordova.preferences,
         whitelist = local.cordova.whitelist,
+        content = conf.content || local.content || 'index.html',
         config_xml_path = path.join(pathHelper.app(), 'config.xml');
 
     if (conf.cordova) {
@@ -38,7 +39,7 @@ module.exports = function (msg) {
         description,
         preferences,
         whitelist,
-        msg.watch || null
+        msg.watch || content
     ).then(function () {
         log.send('success', 'modifying config.xml');
         return msg;


### PR DESCRIPTION
This allows setting different content per configuration. It's useful when using remote content to specify different URLs for different envs like `sta.yourserver.com/index.html` for staging and `localhost:8100/index.html` in dev.

Usage:
```json
"configurations": {
  "ios": {
    "stage": {
      "id": "com.my-company.my-app",
      "product_name": "My App",
      "product_file_name": "my-app",
      "content": "http://sta.my-app.com/index.html"
    }
  }
}
```