### PR TITLE
Add "--device" option to "run" action

### DIFF
--- a/actions/run/ask_device.js
+++ b/actions/run/ask_device.js
@@ -21,6 +21,18 @@ module.exports = function (conf) {
             return conf;
         }
 
+        var findDeviceIndex = function(device) {
+          return ids.findIndex(function(x) { return x.value == device });
+        }
+
+        if (conf.device && findDeviceIndex(conf.device) > -1) {
+          conf.device = {
+              value: conf.device,
+              index: findDeviceIndex(conf.device)
+          };
+          return conf;
+        }
+
         clearInterval(conf.spinner);
 
         return ask.question(
@@ -31,7 +43,7 @@ module.exports = function (conf) {
             if (resp !== 'all')
                 conf.device = {
                     value: resp,
-                    index: ids.indexOf(resp)
+                    index: findDeviceIndex(resp)
                 };
             else
                 conf.devices = ids;

--- a/actions/run/index.js
+++ b/actions/run/index.js
@@ -53,6 +53,7 @@ var run = function (platform, config, localSettings, options) {
         log: options.log,
         all: options.all,
         arch: options.arch,
+        device: options.device,
         spinner: spinner(),
         timeout: options.timeout
     });
@@ -104,6 +105,7 @@ var action = function (argv) {
             log: argsHelper.matchOption(argv, 'l', 'log'),
             all: argsHelper.matchOption(argv, null, 'all'),
             arch: argsHelper.matchOptionWithValue(argv, null, 'arch') && argv.arch,
+            device: argsHelper.matchOptionWithValue(argv, null, 'device') && argv.device,
             timeout: argsHelper.matchOptionWithValue(argv, null, 'timeout') && argv.timeout
         };
     if (!helpOpt && options.log) {

--- a/actions/run/usage.txt
+++ b/actions/run/usage.txt
@@ -18,6 +18,8 @@ Options:
     --timeout <sec>         Browser only: stop serving platform after <s> seconds
                             default is 30 seconds
     --debug, -d             Print helpful stack trace on error
+    --device <DEVICE>       Choose what device to use.
+                            Can be any device name like "Simulator: iPhone-6, 9.2"
 
 Examples:
 


### PR DESCRIPTION
Allows setting device name in "run" action to skip device selection list:

```sh
  tarifa run ios dev --device "Simulator: iPhone-6, 9.2"
```

I also found a bug related to device index. `ids` is an array of objects `{ value: string, index: number }` not strings, so calling `ids.indexOf(resp)` always returns `-1`. I added `findDeviceIndex` function that finds a correct index based on device name.